### PR TITLE
Add `files` to `package.json`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "vows": "0.7.x"
   },
+  "files": ["index.js"],
   "keywords": [
     "topological",
     "sort",


### PR DESCRIPTION
Prevents unused files from being published to NPM.  Saves ~30 KB, mostly from `graph.jpg`.