### PR TITLE
Avoid assigning to exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@
  * @returns {Array}
  */
 
-module.exports = exports = function(edges){
+module.exports = function(edges){
   return toposort(uniqueNodes(edges), edges)
 }
 
-exports.array = toposort
+module.exports.array = toposort
 
 function toposort(nodes, edges) {
   var cursor = nodes.length


### PR DESCRIPTION
Some build systems (e.g. Clojurescript) don't like it if you assign to exports, so `toposort.array` isn't available in these cases