### PR TITLE
Sort large graphs much faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,35 +17,37 @@ function toposort(nodes, edges) {
     , sorted = new Array(cursor)
     , visited = {}
     , i = cursor
+    // Better data structures make algorithm much faster.
+    , outgoingEdges = makeOutgoingEdges(edges)
+    , nodesHash = makeNodesHash(nodes)
 
   while (i--) {
-    if (!visited[i]) visit(nodes[i], i, [])
+    if (!visited[i]) visit(nodes[i], i, {})
   }
 
   return sorted
 
   function visit(node, i, predecessors) {
-    if(predecessors.indexOf(node) >= 0) {
+    if(predecessors.hasOwnProperty(node)) {
       throw new Error('Cyclic dependency: '+JSON.stringify(node))
     }
 
-    if (!~nodes.indexOf(node)) {
+    if (!nodesHash.hasOwnProperty(node)) {
       throw new Error('Found unknown node. Make sure to provided all involved nodes. Unknown node: '+JSON.stringify(node))
     }
 
     if (visited[i]) return;
     visited[i] = true
 
-    // outgoing edges
-    var outgoing = edges.filter(function(edge){
-      return edge[0] === node
-    })
+    var outgoing = Object.keys(outgoingEdges[node] || {})
+
     if (i = outgoing.length) {
-      var preds = predecessors.concat(node)
+      predecessors[node] = true
       do {
-        var child = outgoing[--i][1]
-        visit(child, nodes.indexOf(child), preds)
+        var child = outgoing[--i]
+        visit(child, nodesHash[child], predecessors)
       } while (i)
+      delete predecessors[node]
     }
 
     sorted[--cursor] = node
@@ -53,11 +55,30 @@ function toposort(nodes, edges) {
 }
 
 function uniqueNodes(arr){
-  var res = []
+  var res = {}
   for (var i = 0, len = arr.length; i < len; i++) {
     var edge = arr[i]
-    if (res.indexOf(edge[0]) < 0) res.push(edge[0])
-    if (res.indexOf(edge[1]) < 0) res.push(edge[1])
+    res[edge[0]] = true
+    res[edge[1]] = true
+  }
+  return Object.keys(res)
+}
+
+function makeOutgoingEdges(arr){
+  var edges = {}
+  for (var i = 0, len = arr.length; i < len; i++) {
+    var edge = arr[i]
+    edges[edge[0]] = edges[edge[0]] || {}
+    edges[edge[1]] = edges[edge[1]] || {}
+    edges[edge[0]][edge[1]] = true
+  }
+  return edges
+}
+
+function makeNodesHash(arr){
+  var res = {}
+  for (var i = 0, len = arr.length; i < len; i++) {
+    res[arr[i]] = i
   }
   return res
 }

--- a/test.js
+++ b/test.js
@@ -132,6 +132,23 @@ suite.addBatch(
      assert.deepEqual(result, ['d', 'c', 'a', 'b'])
     }
   }
+, 'giant graphs':
+  {
+    topic: function() {
+      var graph = []
+      for (var i = 0; i < 100000; i++) {
+        graph.push([i, i + 1])
+      }
+      return graph
+    }
+  , 'should sort quickly': function(er, result){
+     var start = (new Date).getTime()
+     var sorted = toposort(result)
+     var end = (new Date).getTime()
+     var elapsedSeconds = (end - start) / 1000
+     assert(elapsedSeconds < 1)
+    }
+  }
 })
 .run(null, function() {
   (suite.results.broken+suite.results.errored) > 0 && process.exit(1)


### PR DESCRIPTION
I needed `toposort` for a project but my graphs had 10k+ vertices and sorting was going way too slowly. Here are some changes I made to make big graphs sort much faster. I also added a test that makes sure a graph with 100k edges can be sorted in under a second (it takes about 300ms on my laptop).

### Before:

```
$ npm test

> toposort@1.0.4 test C:\Users\Sam\projects\toposort
> node test.js

·······✗

    giant graphs
      ✗ should sort quickly
        » false == true
  ✗ Broken » 7 honored ∙ 1 broken (246.595s)
  npm ERR! Test failed.  See above for more details.
```

### After:

```
$ npm test

> toposort@1.0.4 test C:\Users\Sam\projects\toposort
> node test.js

········ ✓ OK » 8 honored (0.362s)
```