### PR TITLE
Improve performance on large graphs (and support non-primative keys)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.6
-  - 0.10
-  - 0.12
   - 4
   - 6
+  - 8

--- a/index.js
+++ b/index.js
@@ -17,35 +17,37 @@ function toposort(nodes, edges) {
     , sorted = new Array(cursor)
     , visited = {}
     , i = cursor
+    // Better data structures make algorithm much faster.
+    , outgoingEdges = makeOutgoingEdges(edges)
+    , nodesHash = makeNodesHash(nodes)
 
   while (i--) {
-    if (!visited[i]) visit(nodes[i], i, [])
+    if (!visited[i]) visit(nodes[i], i, {})
   }
 
   return sorted
 
   function visit(node, i, predecessors) {
-    if(predecessors.indexOf(node) >= 0) {
+    if(predecessors.hasOwnProperty(node)) {
       throw new Error('Cyclic dependency: '+JSON.stringify(node))
     }
 
-    if (!~nodes.indexOf(node)) {
+    if (!nodesHash.hasOwnProperty(node)) {
       throw new Error('Found unknown node. Make sure to provided all involved nodes. Unknown node: '+JSON.stringify(node))
     }
 
     if (visited[i]) return;
     visited[i] = true
 
-    // outgoing edges
-    var outgoing = edges.filter(function(edge){
-      return edge[0] === node
-    })
+    var outgoing = Object.keys(outgoingEdges[node] || {})
+
     if (i = outgoing.length) {
-      var preds = predecessors.concat(node)
+      predecessors[node] = true
       do {
-        var child = outgoing[--i][1]
-        visit(child, nodes.indexOf(child), preds)
+        var child = outgoing[--i]
+        visit(child, nodesHash[child], predecessors)
       } while (i)
+      delete predecessors[node]
     }
 
     sorted[--cursor] = node
@@ -53,11 +55,30 @@ function toposort(nodes, edges) {
 }
 
 function uniqueNodes(arr){
-  var res = []
+  var res = {}
   for (var i = 0, len = arr.length; i < len; i++) {
     var edge = arr[i]
-    if (res.indexOf(edge[0]) < 0) res.push(edge[0])
-    if (res.indexOf(edge[1]) < 0) res.push(edge[1])
+    res[edge[0]] = true
+    res[edge[1]] = true
+  }
+  return Object.keys(res)
+}
+
+function makeOutgoingEdges(arr){
+  var edges = {}
+  for (var i = 0, len = arr.length; i < len; i++) {
+    var edge = arr[i]
+    edges[edge[0]] = edges[edge[0]] || {}
+    edges[edge[1]] = edges[edge[1]] || {}
+    edges[edge[0]][edge[1]] = true
+  }
+  return edges
+}
+
+function makeNodesHash(arr){
+  var res = {}
+  for (var i = 0, len = arr.length; i < len; i++) {
+    res[arr[i]] = i
   }
   return res
 }

--- a/index.js
+++ b/index.js
@@ -22,32 +22,33 @@ function toposort(nodes, edges) {
     , nodesHash = makeNodesHash(nodes)
 
   while (i--) {
-    if (!visited[i]) visit(nodes[i], i, {})
+    if (!visited[i]) visit(nodes[i], i, new Set())
   }
 
   return sorted
 
   function visit(node, i, predecessors) {
-    if(predecessors.hasOwnProperty(node)) {
+    if(predecessors.has(node)) {
       throw new Error('Cyclic dependency: '+JSON.stringify(node))
     }
 
-    if (!nodesHash.hasOwnProperty(node)) {
+    if (!nodesHash.has(node)) {
       throw new Error('Found unknown node. Make sure to provided all involved nodes. Unknown node: '+JSON.stringify(node))
     }
 
     if (visited[i]) return;
     visited[i] = true
 
-    var outgoing = Object.keys(outgoingEdges[node] || {})
+    var outgoing = outgoingEdges.get(node) || new Set()
+    outgoing = Array.from(outgoing)
 
     if (i = outgoing.length) {
-      predecessors[node] = true
+      predecessors.add(node)
       do {
         var child = outgoing[--i]
-        visit(child, nodesHash[child], predecessors)
+        visit(child, nodesHash.get(child), predecessors)
       } while (i)
-      delete predecessors[node]
+      predecessors.delete(node)
     }
 
     sorted[--cursor] = node
@@ -55,30 +56,30 @@ function toposort(nodes, edges) {
 }
 
 function uniqueNodes(arr){
-  var res = {}
+  var res = new Set()
   for (var i = 0, len = arr.length; i < len; i++) {
     var edge = arr[i]
-    res[edge[0]] = true
-    res[edge[1]] = true
+    res.add(edge[0])
+    res.add(edge[1])
   }
-  return Object.keys(res)
+  return Array.from(res)
 }
 
 function makeOutgoingEdges(arr){
-  var edges = {}
+  var edges = new Map()
   for (var i = 0, len = arr.length; i < len; i++) {
     var edge = arr[i]
-    edges[edge[0]] = edges[edge[0]] || {}
-    edges[edge[1]] = edges[edge[1]] || {}
-    edges[edge[0]][edge[1]] = true
+    if (!edges.has(edge[0])) edges.set(edge[0], new Set())
+    if (!edges.has(edge[1])) edges.set(edge[1], new Set())
+    edges.get(edge[0]).add(edge[1])
   }
   return edges
 }
 
 function makeNodesHash(arr){
-  var res = {}
+  var res = new Map()
   for (var i = 0, len = arr.length; i < len; i++) {
-    res[arr[i]] = i
+    res.set(arr[i], i)
   }
   return res
 }

--- a/test.js
+++ b/test.js
@@ -132,6 +132,23 @@ suite.addBatch(
      assert.deepEqual(result, ['d', 'c', 'a', 'b'])
     }
   }
+, 'giant graphs':
+  {
+    topic: function() {
+      var graph = []
+      for (var i = 0; i < 100000; i++) {
+        graph.push([i, i + 1])
+      }
+      return graph
+    }
+  , 'should sort quickly': function(er, result){
+     var start = (new Date).getTime()
+     var sorted = toposort(result)
+     var end = (new Date).getTime()
+     var elapsedSeconds = (end - start) / 1000
+     assert(elapsedSeconds < 1)
+    }
+  }
 })
 .run(null, function() {
   (suite.results.broken+suite.results.errored) > 0 && process.exit(1)

--- a/test.js
+++ b/test.js
@@ -149,6 +149,20 @@ suite.addBatch(
      assert(elapsedSeconds < 1)
     }
   }
+, 'object keys':
+  {
+    topic: function() {
+      var o1 = {k1: 'v1', nested: {k2: 'v2'}}
+      var o2 = {k2: 'v2'}
+      var o3 = {k3: 'v3'}
+      var graph = [[o1, o2], [o2, o3]]
+      return graph
+    }
+  , 'should handle object nodes': function(er, result){
+      var sorted = toposort(result)
+      assert.deepEqual(sorted, [{k1: 'v1', nested: {k2: 'v2'}}, {k2: 'v2'}, {k3: 'v3'}])
+    }
+  }
 })
 .run(null, function() {
   (suite.results.broken+suite.results.errored) > 0 && process.exit(1)


### PR DESCRIPTION
Sorry about the mess yesterday. Now I'm using actual `Map`s and `Set`s and I have a test for sorting objects too.

Unfortunately, really old versions of Node don't support `Map` and `Set` so I removed them from CI. The Node Foundation also stopped supporting them so I don't think it's a big deal: https://github.com/nodejs/Release#release-schedule1