### PR TITLE
document errors thrown when there are cycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ toposort(graph).reverse()
 
 Returns: {Array} a list of vertices, sorted from "start" to "end"
 
+Throws an error if there are any cycles in the graph.
+
 ### toposort.array(nodes, edges)
 
 + nodes {Array} An array of nodes
@@ -84,6 +86,8 @@ Returns: {Array} a list of vertices, sorted from "start" to "end"
 This is a convenience method that allows you to define nodes that may or may not be connected to any other nodes. The ordering of unconnected nodes is not defined.
 
 Returns: {Array} a list of vertices, sorted from "start" to "end"
+
+Throws an error if there are any cycles in the graph.
 
 ## Tests
 


### PR DESCRIPTION
It's important to document that the API is intended to throw an error when there are cycles, rather than having indeterminate behavior.